### PR TITLE
Feature: Persist data on refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@reduxjs/toolkit": "^2.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^9.1.0"
+        "react-redux": "^9.1.0",
+        "redux-persist": "^6.0.0"
       },
       "devDependencies": {
         "@testing-library/dom": "^9.3.4",
@@ -8157,6 +8158,15 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@reduxjs/toolkit": "^2.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^9.1.0"
+    "react-redux": "^9.1.0",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.4",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,10 @@ import React from "react"
 import { createRoot } from "react-dom/client"
 import { CssBaseline } from "@mui/material"
 import { Provider } from "react-redux"
-import { store } from "./app/store"
+import { persistor, store } from "./app/store"
 import { ThemedApp } from "./theme/ThemedApp"
+import { PersistGate } from 'redux-persist/integration/react'
+
 
 const container = document.getElementById("root")
 
@@ -13,8 +15,10 @@ if (container) {
   root.render(
     <React.StrictMode>
         <Provider store={store}>
-          <CssBaseline />
-          <ThemedApp />
+          <PersistGate loading={null} persistor={persistor}>
+            <CssBaseline />
+            <ThemedApp />
+          </PersistGate>
         </Provider>
     </React.StrictMode>,
   )


### PR DESCRIPTION
### Summary

In this PR, `redux-persist` has been introduced. The purpose is to allow for data that is stored in redux to be persisted upon refreshing the page. This will likely mean that the `useLocalStorage()` hook will have less use, but it will remain for now. Maybe in the future, all the pieces that use that hook will be shifted over into redux.

### Changes
- installed `redux-persist`
- configured the application with boilerplate code for this new package