### PR TITLE
Refactor: Load Character Sheet in RTK Query

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -17,6 +17,7 @@ import { quotesApiSlice } from "../features/quotes/quotesApiSlice"
 import { dndApiSlice } from "../dndApp/dndApiSlice"
 import { themeSlice } from "../theme/themeSlice"
 import { spellsSlice } from "../dndApp/spells/spellsSlice"
+import { characterSheetApiSlice } from "../characterSheet/characterSheetApiSlice"
 
 // `combineSlices` automatically combines the reducers using
 // their `reducerPath`s, therefore we no longer need to call `combineReducers`.
@@ -26,6 +27,7 @@ const rootReducer = combineSlices(
   dndApiSlice,
   themeSlice,
   spellsSlice,
+  characterSheetApiSlice,
 )
 
 // Add persisting functionality to reducer
@@ -33,6 +35,7 @@ const persistConfig = {
   key: "root",
   version: 1,
   storage,
+  blacklist: ["api"],
 }
 const persistedReducer = persistReducer(persistConfig, rootReducer)
 
@@ -52,7 +55,11 @@ export const makeStore = (preloadedState?: RootState) => {
           // ignoring redux persist actions
           ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
         },
-      }).concat(quotesApiSlice.middleware, dndApiSlice.middleware)
+      }).concat(
+        quotesApiSlice.middleware,
+        dndApiSlice.middleware,
+        characterSheetApiSlice.middleware,
+      )
     },
     preloadedState,
   })

--- a/src/characterSheet/CharacterSheet.interface.ts
+++ b/src/characterSheet/CharacterSheet.interface.ts
@@ -1,0 +1,71 @@
+/**
+ * The definition for a character sheet
+ */
+export interface CharacterSheet {
+  name: string
+  race: string
+  ability_scores: Array<{
+    name: string
+    modifier: string
+    score: string
+  }>
+  skills: Array<{
+    name: string
+    value: string
+    proficient: boolean
+  }>
+  saving_throws: Array<{
+    name: string
+    modifier: string
+    proficient: boolean
+  }>
+  armor_class: string
+  initiative: string
+  speed: string
+  proficiency_bonus: string
+  hp: {
+    max: number
+    current: number
+  }
+  classes: any
+  gold: number
+  bardic_inspiration: number
+  inspiration: number
+  death_saves: {
+    success: number
+    fail: number
+  }
+  notes: string
+  weapons: Array<{
+    name: string
+    atk: string
+    roll: string
+    modifier: string
+    damage_type: string
+  }>
+  spells: Array<{
+    name: string
+    cost: string
+    roll: string
+    damage: Array<{
+      level: string
+      damage: string
+    }>
+    description: string[]
+    casting_time: string
+    range: string
+    components: string
+    duration: string
+  }>
+  weapon_proficiency: string[]
+  armor_proficiency: string[]
+  language_proficiency: string[]
+  feats_and_traits: Array<{
+    name: string
+    description: string[]
+  }>
+  items_and_equipment: Array<{
+    name: string
+    description: string[]
+  }>
+}

--- a/src/characterSheet/castorRhodesCharacterSheet.ts
+++ b/src/characterSheet/castorRhodesCharacterSheet.ts
@@ -1,0 +1,272 @@
+import { CharacterSheet } from "./characterSheetApiSlice"
+
+export const castorRhodesCharacterSheet: CharacterSheet = {
+  name: "Castor Rhodes",
+  race: "Human",
+  ability_scores: [
+    {
+      name: "STR",
+      modifier: "+4",
+      score: "18",
+    },
+    {
+      name: "DEX",
+      modifier: "+2",
+      score: "14",
+    },
+    {
+      name: "CON",
+      modifier: "+3",
+      score: "16",
+    },
+    {
+      name: "INT",
+      modifier: "-1",
+      score: "9",
+    },
+    {
+      name: "WIS",
+      modifier: "+1",
+      score: "12",
+    },
+    {
+      name: "CHA",
+      modifier: "0",
+      score: "10",
+    },
+  ],
+  skills: [
+    { name: "acrobatics", value: "+2", proficient: false },
+    { name: "animal-handling", value: "+4", proficient: true },
+    { name: "arcana", value: "-1", proficient: false },
+    { name: "athletics", value: "+4", proficient: true },
+    { name: "deception", value: "0", proficient: false },
+    { name: "history", value: "-1", proficient: true },
+    { name: "investigation", value: "-1", proficient: false },
+    { name: "insight", value: "+1", proficient: false },
+    { name: "intimidation", value: "+3", proficient: true },
+    { name: "medicine", value: "+1", proficient: false },
+    { name: "nature", value: "-1", proficient: false },
+    { name: "perception", value: "+1", proficient: false },
+    { name: "performance", value: "0", proficient: false },
+    { name: "persuasion", value: "0", proficient: false },
+    { name: "religion", value: "-1", proficient: false },
+    { name: "sleight-of-hand", value: "+2", proficient: false },
+    { name: "stealth", value: "+2", proficient: false },
+    { name: "survival", value: "+1", proficient: true },
+  ],
+  saving_throws: [
+    { name: "Strength", proficient: true, modifier: "+7" },
+    { name: "Dexterity", proficient: false, modifier: "+2" },
+    { name: "Constitution", proficient: true, modifier: "+6" },
+    { name: "Intelligence", proficient: false, modifier: "-1" },
+    { name: "Wisdom", proficient: false, modifier: "+1" },
+    { name: "Charisma", proficient: false, modifier: "0" },
+  ],
+  armor_class: "15",
+  initiative: "+2",
+  speed: "40/30",
+  proficiency_bonus: "+3",
+  hp: {
+    max: 64,
+    current: 64,
+  },
+  classes: {
+    barbarian: {
+      level: 5,
+      hit_die: "d12",
+      rage_charges: 3,
+    },
+  },
+  gold: 10,
+  bardic_inspiration: 0,
+  inspiration: 0,
+  death_saves: {
+    success: 0,
+    fail: 0,
+  },
+  notes: "",
+  weapons: [
+    {
+      name: "Bloodrage Greataxe",
+      atk: "+7/9",
+      roll: "1d12",
+      modifier: "[+4/+6]",
+      damage_type: "slashing/magical",
+    },
+    {
+      name: "Harpoon",
+      atk: "+7",
+      roll: "1d6",
+      modifier: "+4",
+      damage_type: "piercing",
+    },
+    {
+      name: "Handaxe",
+      atk: "+7",
+      roll: "1d6",
+      modifier: "+4",
+      damage_type: "slashing",
+    },
+    {
+      name: "Handaxe",
+      atk: "+7",
+      roll: "1d6",
+      modifier: "+4",
+      damage_type: "slashing",
+    },
+  ],
+  spells: [
+    {
+      name: "Create Bonfire",
+      cost: "1 Action",
+      roll: "DC 15 DEX",
+      damage: [
+        { level: "1", damage: "1d8 fire" },
+        { level: "5", damage: "2d8 fire" },
+        { level: "11", damage: "3d8 fire" },
+        { level: "17", damage: "4d8 fire" },
+      ],
+      description: [
+        "You create a bonfire on ground that you cansee within range. Until the spell ends, themagic bonfire fills a 5-foot cube. Any creaturein the bonfire’s space when you cast the spellmust succeed on a Dexterity saving throw ortake 1d8 fire damage. A creature must alsomake the saving throw when it moves into thebonfire’s space for the first time on a turn orends its turn there. The bonfire ignitesflammable objects in its area that aren’t beingworn or carried. The spell’s damage increasesby 1d8 when you reach 5th level (2d8), 11thlevel (3d8), and 17th level (4d8).",
+      ],
+      casting_time: "1 Action.",
+      range: "60ft",
+      components: "Verbal, Somatic",
+      duration: "Concentration, 1 min",
+    },
+    {
+      name: "Mending",
+      cost: "1 min",
+      roll: "DC 15 DEX",
+      damage: [{ level: "1", damage: "N / A" }],
+      description: [
+        "This spell repairs a single break or tear in an object you touch, such as a broken chain link, two halves of a broken key, a torn cloak, or a leaking wineskin. As long as the break or tear is no larger than 1 foot in any dimension, you mend it, leaving no trace of the former damage. This spell can physically repair a magic item or construct, but the spell can't restore magic to such an object.",
+      ],
+      casting_time: "1 Action.",
+      range: "Touch",
+      components: "Verbal, Somatic, Material",
+      duration: "Instantaneous",
+    },
+    {
+      name: "Absorb Elements",
+      cost: "1 Reaction",
+      roll: "DC 15 DEX",
+      damage: [
+        { level: "1", damage: "1d6 extra" },
+        { level: "2", damage: "2d6 extra" },
+        { level: "3", damage: "3d6 extra" },
+        { level: "4", damage: "4d6 extra" },
+      ],
+      description: [
+        "The spell captures some of the incoming energy, lessening its effect on you and storing it for your next melee attack. You have resistance to the triggering damage type until the start of your next turn. Also, the first time you hit with a melee attack on your next turn, the target takes an extra 1d6 damage of the triggering type, and the spell ends. At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each slot level above 1st.",
+      ],
+      casting_time: "1 Action.",
+      range: "Self",
+      components: "Somatic",
+      duration: "1 Round",
+    },
+  ],
+  weapon_proficiency: ["Martial", "Simple"],
+  armor_proficiency: ["Light", "Medium", "Shields"],
+  language_proficiency: ["Common", "Grung"],
+  feats_and_traits: [
+    {
+      name: "Rage",
+      description: [
+        "In battle, you fight with primal ferocity. On your turn, you can enter a rage as a bonus action. While raging, you gain the following benefits if you aren't wearing heavy armor:",
+        "- You have advantage on Strength checks and Strength saving throws.",
+        "- When you make a melee weapon Attack using Strength, you gain a +2 bonus to the damage roll. This bonus increases as you level.",
+        "- You have Resistance to bludgeoning, piercing, and slashing damage.",
+        "If you are able to cast Spells, you can't cast them or concentrate on them while raging.",
+        "Your rage lasts for 1 minute. It ends early if you are knocked Unconscious or if Your Turn ends and you haven't attacked a hostile creature since your last turn or taken damage since then. You can also end your rage on Your Turn as a Bonus Action.",
+        "Once you have raged the maximum number of times for your barbarian level, you must finish a Long Rest before you can rage again. You may rage 2 times at 1st level, 3 at 3rd, 4 at 6th, 5 at 12th, and 6 at 17th.",
+      ],
+    },
+    {
+      name: "Danger Sense",
+      description: [
+        "At 2nd level, you gain an uncanny sense of when things nearby aren't as they should be, giving you an edge when you dodge away from danger. You have advantage on Dexterity saving throws against effects that you can see, such as traps and spells. To gain this benefit, you can't be blinded, deafened, or incapacitated.",
+      ],
+    },
+    {
+      name: "Extra Attack",
+      description: [
+        "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.",
+      ],
+    },
+    {
+      name: "Fast Movement",
+      description: [
+        "Starting at 5th level, your speed increases by 10 feet while you aren't wearing heavy armor.",
+      ],
+    },
+    {
+      name: "Great Weapon Master",
+      description: [
+        "You've learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
+        "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
+        "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack's damage.",
+      ],
+    },
+    {
+      name: "Reckless Attack",
+      description: [
+        "Starting at 2nd level, you can throw aside all concern for defense to attack with fierce desperation. When you make your first attack on your turn, you can decide to attack recklessly. Doing so gives you advantage on melee weapon attack rolls using Strength during this turn, but attack rolls against you have advantage until your next turn.",
+      ],
+    },
+    {
+      name: "Storm Aura: Sea",
+      description: [
+        "When you select this path at 3rd level, you emanate a stormy, magical aura while you rage. The aura extends 10 feet from you in every direction, but not through total cover.",
+        "Your aura has an effect that activates when you enter your rage, and you can activate the effect again on each of your turns as a bonus action. Choose desert, sea, or tundra. Your aura's effect depends on that chosen environment, as detailed below. You can change your environment choice whenever you gain a level in this class.",
+        "If your aura's effects require a saving throw, the DC equals 8 + your proficiency bonus + your Constitution modifier.",
+        "Sea. When this effect is activated, you can choose one other creature you can see in your aura. The target must make a Dexterity saving throw. The target takes 1d6 lightning damage on a failed save, or half as much damage on a successful one. The damage increases when you reach certain levels in this class, increasing to 2d6 at 10th level, 3d6 at 15th level, and 4d6 at 20th level.",
+      ],
+    },
+  ],
+  items_and_equipment: [
+    {
+      name: "Clothes, traveler's",
+      description: [],
+    },
+    {
+      name: "Explorer's Pack",
+      description: [],
+    },
+    {
+      name: "Fishing tackle",
+      description: [],
+    },
+    {
+      name: "Pouch",
+      description: [],
+    },
+    {
+      name: "Greater Healing Potion",
+      description: [],
+    },
+    {
+      name: "Soulgaze Monacle",
+      description: [],
+    },
+    {
+      name: "Bottle of Boundless Coffee",
+      description: [],
+    },
+    {
+      name: "Heward's Spice Pouch",
+      description: [],
+    },
+    {
+      name: "Pole of Angling",
+      description: [],
+    },
+    {
+      name: "Bloodrage Greataxe",
+      description: [
+        "You gain a +2 bonus to attack and damage rolls made with this magic greataxe while you have half your hit points or fewer.",
+      ],
+    },
+  ],
+}

--- a/src/characterSheet/characterSheetApiSlice.ts
+++ b/src/characterSheet/characterSheetApiSlice.ts
@@ -1,0 +1,16 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
+import { castorRhodesCharacterSheet } from "./castorRhodesCharacterSheet"
+import { CharacterSheet } from "./CharacterSheet.interface"
+
+export const characterSheetApiSlice = createApi({
+  baseQuery: fetchBaseQuery({ baseUrl: "/" }),
+  endpoints: build => ({
+    getCharacterSheet: build.query<CharacterSheet, void>({
+      queryFn: async () => {
+        return { data: castorRhodesCharacterSheet }
+      },
+    }),
+  }),
+})
+
+export const { useGetCharacterSheetQuery } = characterSheetApiSlice

--- a/src/dndApp/Abilities.tsx
+++ b/src/dndApp/Abilities.tsx
@@ -1,11 +1,11 @@
 import { Button, DialogActions, DialogContent, DialogTitle, Grid2, Typography } from "@mui/material";
-import characterSheet from "./formatted-sheet.json";
 import { useGetAbilityScoreDescriptionQuery } from "./dndApiSlice";
 import { useState } from "react";
 import { StyledStack } from "./StyledStack";
 import { StyledPaper } from "./StyledPaper";
 import { StyledDialog } from "./StyledDialog";
 import { StyledDialogContentText } from "./StyledDialogContentText";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 interface AbilityProps {
     name: string;
@@ -48,13 +48,13 @@ export function Ability({ name, modifier, score }: AbilityProps) {
 
 
 export function Abilities() {
-    const abilityScores = characterSheet.ability_scores;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
 
     return (
         <StyledPaper>
             <Grid2 container spacing={1}>
                 {
-                    abilityScores.map((abilityScore) => {
+                    characterSheet?.ability_scores.map((abilityScore) => {
                         return (
                             <Grid2 size={{ xs: 4, sm: 2 }}>
                                 <Ability 

--- a/src/dndApp/Details.tsx
+++ b/src/dndApp/Details.tsx
@@ -1,15 +1,13 @@
 import { Stack, Typography } from "@mui/material";
 import { Weapons } from "./Weapons";
-import characterSheet from "./formatted-sheet.json";
 import { ItemsAndEquipment } from "./ItemsAndEquipment";
 import { FeatsAndTraits } from "./FeatsAndTraits";
 import { StyledStack } from "./StyledStack";
 import { StyledPaper } from "./StyledPaper";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export function Details() {
-    const weaponProficiencies = characterSheet.weapon_proficiency;
-    const armorProficiencies = characterSheet.armor_proficiency;
-    const languageProficiencies = characterSheet.language_proficiency;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
 
     return (
         <StyledPaper>
@@ -28,7 +26,7 @@ export function Details() {
                 <StyledStack
                     width="100%"
                 >
-                    {weaponProficiencies.map((prof) => {
+                    {characterSheet?.weapon_proficiency.map((prof) => {
                         return (
                             <Typography variant="body1">{prof}</Typography>
                         );
@@ -38,7 +36,7 @@ export function Details() {
                 <StyledStack
                     width="100%"
                 >
-                    {armorProficiencies.map((prof) => {
+                    {characterSheet?.armor_proficiency.map((prof) => {
                         return (
                             <Typography variant="body1">{prof}</Typography>
                         );
@@ -48,7 +46,7 @@ export function Details() {
                 <StyledStack
                     width="100%"
                 >
-                    {languageProficiencies.map((prof) => {
+                    {characterSheet?.language_proficiency.map((prof) => {
                         return (
                             <Typography variant="body1">{prof}</Typography>
                         );

--- a/src/dndApp/DndApp.tsx
+++ b/src/dndApp/DndApp.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid2, Stack, useTheme } from "@mui/material";
+import { Box, CircularProgress, Grid2, Stack, useTheme } from "@mui/material";
 import { Abilities } from "./Abilities";
 import { Details } from "./Details";
 import { General } from "./General";
@@ -7,49 +7,72 @@ import { Skills } from "./Skills";
 import { SavingThrows } from "./SavingThrows";
 import { Notes } from "./Notes";
 import { Spells } from "./spells/Spells";
-import character from "./formatted-sheet.json";
 import { SpellSlots } from "./spells/SpellSlots";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export default function DndApp() {
     const theme = useTheme();
 
+    // Using this query here so that we can have it loaded before rendering everything
+    // I didn't want to go through each component that uses the character sheet and add a loading
+    // circle
+    // As such, all inner components are going under the assumption that the data has been loaded
+    const { data, isFetching } = useGetCharacterSheetQuery();
+
     return (
-        <Box
-            sx={{
-                paddingX: 1,
-                paddingY: 1,
-                gap: 1,
-                bgcolor: theme.background,
-            }}
-        >
-            <Grid2 container spacing={1}>
-                <Grid2 size={{ xs: 12, sm: 12, lg: 12 }}>
-                    <Name />
-                </Grid2>
-                <Grid2 size={{ xs: 12, sm: 12, lg: 12 }}>
-                    <Abilities />
-                </Grid2>
-                <Grid2 size={{ xs: 12, sm: 12, lg: 6 }} order={{ lg: 4 }}>
-                    <Stack spacing={1}>
-                        <General />
-                        <SpellSlots />
-                        <Notes />
+        <>
+            {isFetching && (
+                <Stack
+                    height="100vh"
+                    width="100vw"
+                    justifyContent="center"
+                    alignItems="center"
+                >
+                    <CircularProgress />
+                </Stack>
+            )}
+            {!isFetching && data && <Box
+                sx={{
+                    paddingX: 1,
+                    paddingY: 1,
+                    gap: 1,
+                    bgcolor: theme.background,
+                }}
+            >
+                {isFetching && (
+                    <Stack height="100%" justifyContent="center" alignItems="center">
+                        <CircularProgress />
                     </Stack>
+                )}
+                <Grid2 container spacing={1}>
+                    <Grid2 size={{ xs: 12, sm: 12, lg: 12 }}>
+                        <Name />
+                    </Grid2>
+                    <Grid2 size={{ xs: 12, sm: 12, lg: 12 }}>
+                        <Abilities />
+                    </Grid2>
+                    <Grid2 size={{ xs: 12, sm: 12, lg: 6 }} order={{ lg: 4 }}>
+                        <Stack spacing={1}>
+                            <General />
+                            <SpellSlots />
+                            <Notes />
+                        </Stack>
+                    </Grid2>
+                    <Grid2 size={{ xs: 12, sm: 6, lg: 3 }} order={{ lg: 3 }}>
+                        <Stack spacing={1}>
+                            <SavingThrows />
+                            <Skills />
+                        </Stack>
+                    </Grid2>
+                    <Grid2 size={{ xs: 12, sm: 6, lg: 3 }} order={{ lg: 4 }}>
+                        <Stack spacing={1}>
+                            {data.spells.length > 0 && <Spells />}
+                            <Details />
+                        </Stack>
+                    </Grid2>
                 </Grid2>
-                <Grid2 size={{ xs: 12, sm: 6, lg: 3 }} order={{ lg: 3 }}>
-                    <Stack spacing={1}>
-                        <SavingThrows />
-                        <Skills />
-                    </Stack>
-                </Grid2>
-                <Grid2 size={{ xs: 12, sm: 6, lg: 3 }} order={{ lg: 4 }}>
-                    <Stack spacing={1}>
-                        {character.spells.length > 0 && <Spells />}
-                        <Details />
-                    </Stack>
-                </Grid2>
-            </Grid2>
-        </Box>
+            </Box>}
+        </>
     );
 }
 

--- a/src/dndApp/FeatsAndTraits.tsx
+++ b/src/dndApp/FeatsAndTraits.tsx
@@ -1,10 +1,10 @@
 import { Stack, Typography } from "@mui/material";
 import { ThingWithDescription } from "./ThingWithDescription";
 import { StyledStack } from "./StyledStack";
-import characterSheet from "./formatted-sheet.json";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export function FeatsAndTraits() {
-    const featsAndTraits = characterSheet.feats_and_traits;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
 
     return (
         <Stack
@@ -13,7 +13,7 @@ export function FeatsAndTraits() {
         >
             <Typography variant="body1" sx={{ fontWeight: "bold" }}>Feats & Traits</Typography>
             <StyledStack width="100%">
-                {featsAndTraits.map((featOrTrait) => {
+                {characterSheet?.feats_and_traits.map((featOrTrait) => {
                     return <ThingWithDescription name={featOrTrait.name} description={featOrTrait.description} />
                 })}
             </StyledStack>

--- a/src/dndApp/ItemsAndEquipment.tsx
+++ b/src/dndApp/ItemsAndEquipment.tsx
@@ -1,17 +1,18 @@
 import { Typography } from "@mui/material";
 import { ThingWithDescription } from "./ThingWithDescription";
-import characterSheet from "./formatted-sheet.json";
 import { StyledStack } from "./StyledStack";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export function ItemsAndEquipment() {
-    const { items_and_equipment } = characterSheet;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
+
     return (
         <>
             <Typography variant="body1" sx={{ fontWeight: "bold" }}>Items & Equipment</Typography>
             <StyledStack
                 width="100%"
             >
-                {items_and_equipment.map((itemOrEquipment) => {
+                {characterSheet?.items_and_equipment.map((itemOrEquipment) => {
                     return <ThingWithDescription name={itemOrEquipment.name} description={itemOrEquipment.description} />
                 })}
             </StyledStack>

--- a/src/dndApp/Name.tsx
+++ b/src/dndApp/Name.tsx
@@ -1,11 +1,13 @@
 import { Typography } from "@mui/material";
-import characterSheet from "./formatted-sheet.json"
 import { StyledPaper } from "./StyledPaper";
 import { useAppDispatch } from "../app/hooks";
 import { cycleTheme } from "../theme/themeSlice";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export function Name() {
     const dispatch = useAppDispatch();
+    const { data: characterSheet } = useGetCharacterSheetQuery();
+
     return (
         <StyledPaper
             sx={{
@@ -18,7 +20,7 @@ export function Name() {
                 dispatch(cycleTheme())
             }}
         >
-            <Typography variant="h4">Level {characterSheet.classes.barbarian.level}: {characterSheet.name}</Typography>
+            <Typography variant="h4">Level {characterSheet?.classes.barbarian.level}: {characterSheet?.name}</Typography>
         </StyledPaper>
     );
 }

--- a/src/dndApp/SavingThrows.tsx
+++ b/src/dndApp/SavingThrows.tsx
@@ -1,10 +1,10 @@
 import { Box, Typography } from "@mui/material";
-import characterSheet from "./formatted-sheet.json";
 import { StyledStack } from "./StyledStack";
 import { StyledPaper } from "./StyledPaper";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export function SavingThrows() {
-    const skills = characterSheet.saving_throws;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
 
     return (
         <StyledPaper>
@@ -17,9 +17,9 @@ export function SavingThrows() {
             }}>
                 <Typography variant="body1" sx={{ fontWeight: "bold" }}>Saving Throws</Typography>
                 {
-                    skills.map(({ name, modifier, proficient }) => {
+                    characterSheet?.saving_throws.map(({ name, modifier, proficient }) => {
                         return (
-                            <Skill name={name} statValue={modifier} proficient={proficient} />
+                            <SavingThrow name={name} statValue={modifier} proficient={proficient} />
                         );
                     })
                 }
@@ -28,12 +28,12 @@ export function SavingThrows() {
     );
 }
 
-interface SavingThrowsProps {
+interface SavingThrowProps {
     name: string;
     statValue: string | boolean;
     proficient: boolean;
 }
-export function Skill({ name, statValue, proficient }: SavingThrowsProps) {
+export function SavingThrow({ name, statValue, proficient }: SavingThrowProps) {
     const skillName = `${name.slice(0,1).toUpperCase()}${name.slice(1)}`.replace(/-/g, " ")
 
     return (

--- a/src/dndApp/Skills.tsx
+++ b/src/dndApp/Skills.tsx
@@ -1,22 +1,22 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { Button, DialogActions, DialogContent, DialogTitle, Stack, Typography } from "@mui/material";
-import characterSheet from "./formatted-sheet.json";
 import { useGetSkillsDescriptionQuery } from "./dndApiSlice";
 import { useState } from "react";
 import { StyledStack } from "./StyledStack";
 import { StyledPaper } from "./StyledPaper";
 import { StyledDialog } from "./StyledDialog";
 import { StyledDialogContentText } from "./StyledDialogContentText";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 export function Skills() {
-    const skills = characterSheet.skills;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
 
     return (
         <StyledPaper>
             <Stack spacing={1} alignItems="center">
                 <Typography variant="body1" sx={{ fontWeight: "bold" }}>Skills</Typography>
                 {
-                    skills.map(({ name, value, proficient }) => {
+                    characterSheet?.skills.map(({ name, value, proficient }) => {
                         return (
                             <Skill name={name} statValue={value} proficient={proficient} />
                         );

--- a/src/dndApp/Weapons.tsx
+++ b/src/dndApp/Weapons.tsx
@@ -1,8 +1,8 @@
 import type { SxProps} from "@mui/material";
 import { Stack, Typography, useTheme } from "@mui/material";
-import characterSheet from "./formatted-sheet.json";
 import { StyledStack } from "./StyledStack";
 import useLocalStorage from "./useLocalStorage";
+import { useGetCharacterSheetQuery } from "../characterSheet/characterSheetApiSlice";
 
 interface WeaponProps {
     id: string;
@@ -58,7 +58,7 @@ export function Weapon({ id, name, atk, roll, modifier, damage_type }: WeaponPro
 
 
 export function Weapons() {
-    const { weapons } = characterSheet;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
 
     return (
         <Stack
@@ -72,7 +72,7 @@ export function Weapons() {
                 width="100%"
                 spacing={1}
             >
-                {weapons.map(({ name, atk, roll, modifier, damage_type }, index) => {
+                {characterSheet?.weapons.map(({ name, atk, roll, modifier, damage_type }, index) => {
                     return (
                         <Weapon
                             id={`${name}-${index}`}

--- a/src/dndApp/spells/Spells.tsx
+++ b/src/dndApp/spells/Spells.tsx
@@ -4,7 +4,7 @@ import { StyledStack } from "../StyledStack";
 import { useState } from "react";
 import { StyledDialog } from "../StyledDialog";
 import { StyledDialogContentText } from "../StyledDialogContentText";
-import character from "../formatted-sheet.json";
+import { useGetCharacterSheetQuery } from "../../characterSheet/characterSheetApiSlice";
 
 interface SpellProps {
     name: string;
@@ -105,7 +105,8 @@ export function Spell({
 }
 
 export function Spells() {
-    const spells = character.spells;
+    const { data: characterSheet } = useGetCharacterSheetQuery();
+
     return (
         <StyledPaper>
             <Stack spacing={1} alignItems="center" width="100%">
@@ -115,7 +116,7 @@ export function Spells() {
                 width="100%"
                 spacing={1}
                 >
-                    {spells.map(spell => {
+                    {characterSheet?.spells.map(spell => {
                         return (
                             <Spell
                                 name={spell.name}


### PR DESCRIPTION
### Summary

In this PR, the character sheet has been moved from a JSON file into a hardcoded variable that is loaded through an RTK Query API.

The goal for this is to eventually have other character sheets loaded from a database. This is the first step to get the components to read from asynchronous logic.

### Changes
-  Moved all character sheet references from the JSON file to be loaded from the RTK Query API slice
- Added a big loading circle at the very base of the webpage
